### PR TITLE
[B] feat: 기본 규칙 추가, 미래 회차에 참여자 제거, 현재 참여 여부 추가

### DIFF
--- a/backend/src/main/java/ssu/groupstudy/domain/round/domain/Round.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/round/domain/Round.java
@@ -13,10 +13,12 @@ import ssu.groupstudy.global.domain.BaseEntity;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Collectors;
 
-import static javax.persistence.CascadeType.PERSIST;
+import static javax.persistence.CascadeType.ALL;
 import static javax.persistence.FetchType.LAZY;
 
 @Entity
@@ -34,7 +36,7 @@ public class Round extends BaseEntity {
     @Embedded
     private Appointment appointment;
 
-    @OneToMany(mappedBy = "round", cascade = PERSIST)
+    @OneToMany(mappedBy = "round", cascade = ALL, orphanRemoval = true)
     private final List<RoundParticipant> roundParticipants = new ArrayList<>();
 
     @ManyToOne(fetch = LAZY)
@@ -67,6 +69,10 @@ public class Round extends BaseEntity {
             return;
         }
         roundParticipants.add(participant);
+    }
+
+    public void removeParticipant(RoundParticipant participant){
+        roundParticipants.remove(participant);
     }
 
     public void updateAppointment(Appointment appointment) {

--- a/backend/src/main/java/ssu/groupstudy/domain/rule/domain/Rule.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/rule/domain/Rule.java
@@ -30,10 +30,14 @@ public class Rule extends BaseEntity {
     @JoinColumn(name="studyId", nullable = false)
     private Study study;
 
-    public Rule(String detail, Study study){
+    private Rule(String detail, Study study){
         this.detail = detail;
         this.study = study;
         this.deleteYn = 'N';
+    }
+
+    public static Rule create(String detail, Study study){
+        return new Rule(detail, study);
     }
 
     public void delete() {

--- a/backend/src/main/java/ssu/groupstudy/domain/rule/dto/request/CreateRuleRequest.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/rule/dto/request/CreateRuleRequest.java
@@ -19,6 +19,6 @@ public class CreateRuleRequest {
     private String detail;
 
     public Rule toEntity(Study study){
-        return new Rule(this.detail, study);
+        return Rule.create(this.detail, study);
     }
 }

--- a/backend/src/main/java/ssu/groupstudy/domain/study/api/ParticipantApi.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/study/api/ParticipantApi.java
@@ -37,6 +37,13 @@ public class ParticipantApi {
         return ResponseDto.success();
     }
 
+    @Operation(summary = "스터디 회원 강퇴하기", description = "방장만 해당 기능을 이용할 수 있다")
+    @DeleteMapping("/kick")
+    public ResponseDto kickParticipant(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam Long userId, @RequestParam Long studyId){
+        participantsService.kickParticipant(userDetails.getUser(), userId, studyId);
+        return ResponseDto.success();
+    }
+
     @Operation(summary = "스터디에 소속된 사용자의 프로필 이미지를 모두 불러온다", description = "가입 시각을 기준으로 오름차순 정렬한다")
     @GetMapping("/summary")
     public ResponseDto getParticipantsProfileImageList(@RequestParam Long studyId){
@@ -49,12 +56,5 @@ public class ParticipantApi {
     public ResponseDto getParticipant(@RequestParam Long userId, @RequestParam Long studyId){
         ParticipantResponse participant = participantsService.getParticipant(userId, studyId);
         return DataResponseDto.of("participant", participant);
-    }
-
-    @Operation(summary = "스터디 회원 강퇴하기", description = "방장만 해당 기능을 이용할 수 있다")
-    @DeleteMapping("/kick")
-    public ResponseDto kickParticipant(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam Long userId, @RequestParam Long studyId){
-        participantsService.kickParticipant(userDetails.getUser(), userId, studyId);
-        return ResponseDto.success();
     }
 }

--- a/backend/src/main/java/ssu/groupstudy/domain/study/dto/response/ParticipantResponse.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/study/dto/response/ParticipantResponse.java
@@ -21,9 +21,10 @@ public class ParticipantResponse {
     private List<StatusTagInfo> statusTagInfoList;
     private int doneRate;
     private int unDoneRate;
+    private char isParticipated;
 
 
-    private ParticipantResponse(User user, List<ParticipantInfo> participantInfoList, List<StatusTagInfo> statusTagInfoList, DoneCount doneCount) {
+    private ParticipantResponse(User user, List<ParticipantInfo> participantInfoList, List<StatusTagInfo> statusTagInfoList, DoneCount doneCount, char isParticipated) {
         this.userId = user.getUserId();
         this.nickname = user.getNickname();
         this.profileImage = user.getPicture();
@@ -32,9 +33,10 @@ public class ParticipantResponse {
         this.statusTagInfoList = statusTagInfoList;
         this.doneRate = doneCount.getDoneRate();
         this.unDoneRate = doneCount.getUndoneRate();
+        this.isParticipated = isParticipated;
     }
 
-    public static ParticipantResponse of(User user, List<ParticipantInfo> participantInfoList, List<StatusTagInfo> statusTagInfo, DoneCount doneCount) {
-        return new ParticipantResponse(user, participantInfoList, statusTagInfo, doneCount);
+    public static ParticipantResponse of(User user, List<ParticipantInfo> participantInfoList, List<StatusTagInfo> statusTagInfo, DoneCount doneCount, char isParticipated) {
+        return new ParticipantResponse(user, participantInfoList, statusTagInfo, doneCount, isParticipated);
     }
 }

--- a/backend/src/main/java/ssu/groupstudy/domain/study/service/ParticipantsService.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/study/service/ParticipantsService.java
@@ -63,10 +63,12 @@ public class ParticipantsService {
         List<ParticipantInfo> participantInfoList = participantRepository.findStudyNamesByUser(user);
         List<StatusTagInfo> statusTagInfoList = handleStatusTagInfo(study, user);
         DoneCount doneCount = studyRepository.calculateDoneCount(user, study);
+        char isParticipated = (study.isParticipated(user)) ? 'Y' : 'N';
 
-        return ParticipantResponse.of(user, participantInfoList, statusTagInfoList, doneCount);
+        return ParticipantResponse.of(user, participantInfoList, statusTagInfoList, doneCount, isParticipated);
     }
 
+    // TODO : refactoring (modern java in action)
     private List<StatusTagInfo> handleStatusTagInfo(Study study, User user) {
         List<StatusTagInfo> statusTagInfos = studyRepository.calculateStatusTag(user, study);
         EnumSet<StatusTag> statusTags = EnumSet.allOf(StatusTag.class);

--- a/backend/src/main/java/ssu/groupstudy/domain/study/service/StudyInviteService.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/study/service/StudyInviteService.java
@@ -60,7 +60,15 @@ public class StudyInviteService {
     public void leaveUser(User user, Long studyId) {
         Study study = studyRepository.findById(studyId)
                 .orElseThrow(() -> new StudyNotFoundException(ResultCode.STUDY_NOT_FOUND));
+        removeUserToFutureRounds(study, user);
         eventPublisher.publishEvent(new StudyTopicUnsubscribeEvent(user, study));
         study.leave(user);
+    }
+
+    private void removeUserToFutureRounds(Study study, User user) {
+        List<Round> futureRounds = roundRepository.findFutureRounds(study, LocalDateTime.now());
+        for (Round round : futureRounds) {
+            round.removeParticipant(new RoundParticipant(user, round));
+        }
     }
 }

--- a/backend/src/main/java/ssu/groupstudy/domain/study/service/StudyService.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/study/service/StudyService.java
@@ -13,6 +13,8 @@ import ssu.groupstudy.domain.round.domain.RoundParticipant;
 import ssu.groupstudy.domain.round.dto.request.AppointmentRequest;
 import ssu.groupstudy.domain.round.repository.RoundParticipantRepository;
 import ssu.groupstudy.domain.round.repository.RoundRepository;
+import ssu.groupstudy.domain.rule.domain.Rule;
+import ssu.groupstudy.domain.rule.repository.RuleRepository;
 import ssu.groupstudy.domain.study.domain.Participant;
 import ssu.groupstudy.domain.study.domain.Study;
 import ssu.groupstudy.domain.study.dto.request.CreateStudyRequest;
@@ -48,6 +50,7 @@ public class StudyService {
     private final ParticipantRepository participantRepository;
     private final RoundRepository roundRepository;
     private final RoundParticipantRepository roundParticipantRepository;
+    private final RuleRepository ruleRepository;
     private final S3Utils s3Utils;
     private final ApplicationEventPublisher eventPublisher;
     private final int INVITE_CODE_LENGTH = 6;
@@ -71,7 +74,10 @@ public class StudyService {
 
     private Study createNewStudy(CreateStudyRequest dto, User user) {
         String inviteCode = generateUniqueInviteCode();
-        return studyRepository.save(dto.toEntity(user, inviteCode));
+        Study study = studyRepository.save(dto.toEntity(user, inviteCode));
+        createDefaultRound(study);
+        createDefaultRule(study);
+        return study;
     }
 
     private String generateUniqueInviteCode() {
@@ -90,6 +96,11 @@ public class StudyService {
                 .build();
         Round defaultRound = roundRepository.save(appointment.toEntity(study));
         createDefaultTask(defaultRound);
+    }
+
+    private void createDefaultRule(Study study) {
+        Rule rule = Rule.create("스터디 규칙을 추가해보세요!", study);
+        ruleRepository.save(rule);
     }
 
     private void createDefaultTask(Round defaultRound) {

--- a/backend/src/main/java/ssu/groupstudy/domain/study/service/StudyService.java
+++ b/backend/src/main/java/ssu/groupstudy/domain/study/service/StudyService.java
@@ -61,7 +61,6 @@ public class StudyService {
         canCreateNewStudy(user);
         Study study = createNewStudy(dto, user);
         handleUploadProfileImage(study, image);
-        createDefaultRound(study);
         eventPublisher.publishEvent(new StudyTopicSubscribeEvent(user, study));
         return StudyCreateResponse.of(study.getStudyId(), study.getInviteCode());
     }

--- a/backend/src/test/java/ssu/groupstudy/domain/study/service/ParticipantsServiceTest.java
+++ b/backend/src/test/java/ssu/groupstudy/domain/study/service/ParticipantsServiceTest.java
@@ -6,11 +6,18 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import ssu.groupstudy.domain.common.ServiceTest;
+import ssu.groupstudy.domain.study.domain.Study;
+import ssu.groupstudy.domain.study.dto.DoneCount;
+import ssu.groupstudy.domain.study.dto.response.ParticipantResponse;
 import ssu.groupstudy.domain.study.exception.StudyNotFoundException;
 import ssu.groupstudy.domain.study.repository.ParticipantRepository;
 import ssu.groupstudy.domain.study.repository.StudyRepository;
+import ssu.groupstudy.domain.user.domain.User;
+import ssu.groupstudy.domain.user.exception.UserNotFoundException;
+import ssu.groupstudy.domain.user.repository.UserRepository;
 import ssu.groupstudy.global.constant.ResultCode;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -22,6 +29,8 @@ class ParticipantsServiceTest extends ServiceTest {
     private ParticipantsService participantsService;
     @Mock
     private StudyRepository studyRepository;
+    @Mock
+    private UserRepository userRepository;
     @Mock
     private ParticipantRepository participantRepository;
 
@@ -52,5 +61,52 @@ class ParticipantsServiceTest extends ServiceTest {
 //            // then
 //            assertEquals(2, participantSummaryList.size());
 //        }
+    }
+
+    @Nested
+    class GetParticipant{
+        @Test
+        @DisplayName("스터디가 존재하지 않으면 예외를 던진다")
+        void studyNotFound(){
+            // given
+            // when
+            doReturn(Optional.empty()).when(studyRepository).findById(any(Long.class));
+
+            // then
+            assertThatThrownBy(() -> participantsService.getParticipant(-1L, -1L))
+                    .isInstanceOf(StudyNotFoundException.class)
+                    .hasMessage(ResultCode.STUDY_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("사용자가 존재하지 않으면 예외를 던진다")
+        void userNotFound(){
+            // given
+            // when
+            doReturn(Optional.of(알고리즘스터디)).when(studyRepository).findById(any(Long.class));
+            doReturn(Optional.empty()).when(userRepository).findById(any(Long.class));
+
+            // then
+            assertThatThrownBy(() -> participantsService.getParticipant(-1L, -1L))
+                    .isInstanceOf(UserNotFoundException.class)
+                    .hasMessage(ResultCode.USER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("스터디에 초대되어 있는지 검사한다")
+        void isParticipated(){
+            // given
+            doReturn(Optional.of(알고리즘스터디)).when(studyRepository).findById(any(Long.class));
+            doReturn(Optional.of(최규현)).when(userRepository).findById(any(Long.class));
+            doReturn(List.of()).when(participantRepository).findStudyNamesByUser(any(User.class));
+            doReturn(new DoneCount(0L,0L,0L)).when(studyRepository).calculateDoneCount(any(User.class), any(Study.class));
+
+            // when
+            ParticipantResponse response = participantsService.getParticipant(-1L, -1L);
+            char isParticipated = response.getIsParticipated();
+
+            // then
+            softly.assertThat(isParticipated).isEqualTo('Y');
+        }
     }
 }

--- a/backend/src/test/java/ssu/groupstudy/domain/study/service/StudyServiceTest.java
+++ b/backend/src/test/java/ssu/groupstudy/domain/study/service/StudyServiceTest.java
@@ -10,6 +10,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import ssu.groupstudy.domain.common.ServiceTest;
 import ssu.groupstudy.domain.round.domain.Round;
 import ssu.groupstudy.domain.round.repository.RoundRepository;
+import ssu.groupstudy.domain.rule.repository.RuleRepository;
 import ssu.groupstudy.domain.study.domain.Participant;
 import ssu.groupstudy.domain.study.domain.Study;
 import ssu.groupstudy.domain.study.dto.response.StudyCreateResponse;
@@ -40,6 +41,8 @@ class StudyServiceTest extends ServiceTest {
     @Mock
     private RoundRepository roundRepository;
     @Mock
+    private RuleRepository ruleRepository;
+    @Mock
     private ApplicationEventPublisher eventPublisher;
     @Mock
     private S3Utils s3Utils;
@@ -50,8 +53,8 @@ class StudyServiceTest extends ServiceTest {
         @DisplayName("프로필 사진을 함께 요청하면 스터디를 생성하면서 업로드한다.")
         void uploadStudyProfileImage() throws IOException {
             // given
-            doReturn(알고리즘스터디).when(studyRepository).save(any(Study.class));
             final String PROFILE_IMAGE = "profileImage";
+            doReturn(알고리즘스터디).when(studyRepository).save(any(Study.class));
             doReturn(PROFILE_IMAGE).when(s3Utils).uploadProfileImage(any(), any(), any(Long.class));
             doReturn(Round.builder()
                     .study(알고리즘스터디)


### PR DESCRIPTION
* 스터디 생성 시에 기본 규칙을 추가하도록 했습니다. 문구 "스터디 규칙을 추가해보세요!"
* 스터디 탈퇴 및 강퇴 시에 미래 회차에서 제거하도록 구현했습니다.
* 스터디 회원 상세보기 api 호출 시 현재 참여 여부를 검사하는 필드를 추가했습니다.